### PR TITLE
Add support for Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.4|^8.0|^8.1",
         "illuminate/http": "^8.0|^9.0|^10.0",
         "illuminate/routing": "^8.0|^9.0|^10.0",
         "illuminate/support": "^8.0|^9.0|^10.0"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "friendsofphp/php-cs-fixer": "^3.9.5",
         "mockery/mockery": "^1.5",
         "orchestra/testbench": "^6.24|^8.1.1",
-        "phpstan/phpstan": "^0.12.2",
+        "phpstan/phpstan": "^0.12.2|^1.10",
         "phpunit/phpunit": "^8.5|^9.6"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/http": "^8.0|^9.0",
-        "illuminate/routing": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0"
+        "illuminate/http": "^8.0|^9.0|^10.0",
+        "illuminate/routing": "^8.0|^9.0|^10.0",
+        "illuminate/support": "^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.9.5",

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.9.5",
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^6.24",
+        "orchestra/testbench": "^6.24|^8.1.1",
         "phpstan/phpstan": "^0.12.2",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^8.5|^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/ReplayResponse.php
+++ b/src/ReplayResponse.php
@@ -9,6 +9,9 @@ use Illuminate\Http\Response as LaravelResponse;
 use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+/**
+ * @implements Arrayable<string, mixed>
+ */
 class ReplayResponse implements Arrayable, Responsable
 {
     private string $content;


### PR DESCRIPTION
Allows the package to be installed using the v10 versions of these dependencies:
- illuminate/http
- illuminate/routing
- illuminate/support

Also allows installs using php 8.1